### PR TITLE
Define color16-color21 in the 256 variant

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ Simply copy the contents of your desired color scheme into your `kitty.conf` fil
  - macOS: `~/Library/Preferences/kitty/kitty.conf`
 
 # `256` Variants
-The 256 variants are for those who wish to continue using the 16 ANSI colors but don't want to end up with weird-looking colors instead of bright ones. Because base16 schemes are only 16-color, all of the bright colors mirror their non-bright variants instead of being unique colors. If you use the 256 variants, you will also need to use [base16-shell](https://github.com/chriskempson/base16-shell) to maintain proper compatibility with the base16 themes.
 
-### TL;DR if some colors look weird, darker than normal, or incorrect, try a `256` variant.
+The 256 variants are for those who wish to continue using the 16 ANSI colors but don't want to end up with weird-looking colors instead of bright ones. Because base16 schemes have 16 colors only, the bright colors mirror their non-bright variants instead of being unique colors.
+
+### TL;DR if some colors look weird, darker than normal, or incorrect, try the `256` variant.

--- a/templates/default-256.mustache
+++ b/templates/default-256.mustache
@@ -26,3 +26,11 @@ color12 #{{base0D-hex}}
 color13 #{{base0E-hex}}
 color14 #{{base0C-hex}}
 color15 #{{base05-hex}}
+
+# extended base16 colors
+color16 #{{base09-hex}}
+color17 #{{base0F-hex}}
+color18 #{{base01-hex}}
+color19 #{{base02-hex}}
+color20 #{{base04-hex}}
+color21 #{{base06-hex}}


### PR DESCRIPTION
There is no need to use base16-shell, since kitty supports setting
colors 16-21.