### PR TITLE
Add tab_bar_background

### DIFF
--- a/templates/default-256.mustache
+++ b/templates/default-256.mustache
@@ -12,6 +12,7 @@ active_tab_background #{{base00-hex}}
 active_tab_foreground #{{base05-hex}}
 inactive_tab_background #{{base01-hex}}
 inactive_tab_foreground #{{base04-hex}}
+tab_bar_background #{{base01-hex}}
 
 # normal
 color0 #{{base00-hex}}

--- a/templates/default.mustache
+++ b/templates/default.mustache
@@ -12,6 +12,7 @@ active_tab_background #{{base00-hex}}
 active_tab_foreground #{{base05-hex}}
 inactive_tab_background #{{base01-hex}}
 inactive_tab_foreground #{{base04-hex}}
+tab_bar_background #{{base01-hex}}
 
 # normal
 color0 #{{base00-hex}}


### PR DESCRIPTION
Adds tab_bar_background color.

Before:
<img width="419" alt="Screen Shot 2020-05-11 at 13 39 04" src="https://user-images.githubusercontent.com/2834949/81557751-ca7b3c80-938c-11ea-9516-d1860e4f02ce.png">


After:
<img width="471" alt="Screen Shot 2020-05-11 at 13 36 55" src="https://user-images.githubusercontent.com/2834949/81557644-999b0780-938c-11ea-9fcd-a1fd46f7f27c.png">
