### PR TITLE
Added MacOS and Wayland Title Bars

### DIFF
--- a/templates/default-256.mustache
+++ b/templates/default-256.mustache
@@ -13,6 +13,8 @@ active_tab_foreground #{{base05-hex}}
 inactive_tab_background #{{base01-hex}}
 inactive_tab_foreground #{{base04-hex}}
 tab_bar_background #{{base01-hex}}
+wayland_titlebar_color #{{base00-hex}}
+macos_titlebar_color #{{base00-hex}}
 
 # normal
 color0 #{{base00-hex}}

--- a/templates/default.mustache
+++ b/templates/default.mustache
@@ -13,6 +13,8 @@ active_tab_foreground #{{base05-hex}}
 inactive_tab_background #{{base01-hex}}
 inactive_tab_foreground #{{base04-hex}}
 tab_bar_background #{{base01-hex}}
+wayland_titlebar_color #{{base00-hex}}
+macos_titlebar_color #{{base00-hex}}
 
 # normal
 color0 #{{base00-hex}}


### PR DESCRIPTION
On MacOS and Wayland you can change the titlebar to match the theme, which makes the terminal look much more unified, see before:
<img width="756" alt="image" src="https://github.com/kdrag0n/base16-kitty/assets/13283054/2e16dbca-b5c5-4bd9-bf75-a25c57196e6b">
And after:
<img width="758" alt="image" src="https://github.com/kdrag0n/base16-kitty/assets/13283054/892a34c0-9574-4f24-8a79-c3a9b74e0582">