### PR TITLE
Add cursor_text_color

### DIFF
--- a/templates/default-256.mustache
+++ b/templates/default-256.mustache
@@ -6,6 +6,7 @@ selection_background #{{base05-hex}}
 selection_foreground #{{base00-hex}}
 url_color #{{base04-hex}}
 cursor #{{base05-hex}}
+cursor_text_color #{{base00-hex}}
 active_border_color #{{base03-hex}}
 inactive_border_color #{{base01-hex}}
 active_tab_background #{{base00-hex}}

--- a/templates/default.mustache
+++ b/templates/default.mustache
@@ -6,6 +6,7 @@ selection_background #{{base05-hex}}
 selection_foreground #{{base00-hex}}
 url_color #{{base04-hex}}
 cursor #{{base05-hex}}
+cursor_text_color #{{base00-hex}}
 active_border_color #{{base03-hex}}
 inactive_border_color #{{base01-hex}}
 active_tab_background #{{base00-hex}}


### PR DESCRIPTION
By default, Kitty is setting the cursor text color to #111111.

See https://sw.kovidgoyal.net/kitty/conf/#opt-kitty.cursor_text_color.

It's not rendering well when using vim with light theme.

![screenshot-2024-07-15-181827](https://github.com/user-attachments/assets/776f0881-fcf1-4e0b-8ff9-480cf32b3a2c)
